### PR TITLE
Trim command line arguments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,19 +4,19 @@ set -ex
 while getopts ":t:c:l:o:f:" o; do
   case "${o}" in
   t)
-    export imageName=${OPTARG}
+    export imageName="$(echo "${OPTARG}" | sed 's/^ *\| *$//')"
     ;;
   c)
-    export exitCode=${OPTARG}
+    export exitCode="$(echo "${OPTARG}" | sed 's/^ *\| *$//')"
     ;;
   l)
-    export exitLevel=${OPTARG}
+    export exitLevel="$(echo "${OPTARG}" | sed 's/^ *\| *$//')"
     ;;
   o)
-    export output=${OPTARG}
+    export output="$(echo "${OPTARG}" | sed 's/^ *\| *$//')"
     ;;
   f)
-    export format=${OPTARG}
+    export format="$(echo "${OPTARG}" | sed 's/^ *\| *$//')"
     ;;
   \?)
     echo "unknown flag"


### PR DESCRIPTION
https://github.com/goodwithtech/dockle-action/blob/11c82d478fec09ed1aa56d933eab25218e22bb90/entrypoint.sh#L53-L55


It is not correctly determined whether to execute dockle twice because command line arguments `$output` ( `-o` ) and `$exitCode` ( `-c` ) are not trimmed.
Therefore, I fix to trim command line arguments.