### PR TITLE
Upgrade Dockle to `0.4.14`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM goodwithtech/dockle:v0.4.13
+FROM goodwithtech/dockle:v0.4.14
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
[An issue](https://github.com/goodwithtech/dockle/issues/251) was reported to Dockle, which was fixed upstream in `0.4.14`. This same issue [is reported for `dockle-action`](https://github.com/goodwithtech/dockle-action/issues/7).

Resolved by upgrading Dockle to `0.4.14`.

Fixes https://github.com/goodwithtech/dockle-action/issues/7