### PR TITLE
doc: Ubuntu 20 runner image brownout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
# ❔ About

[Ubuntu 20 runner image brownout](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), this PR documents this.

🙏 Thanks a lot for the great software, we use it a lot and now it's part of our stack, on dev workstation and on our GH CI.